### PR TITLE
Add passage feedback with AI disclosure and Slack notification

### DIFF
--- a/site/app/api/passage-feedback/route.ts
+++ b/site/app/api/passage-feedback/route.ts
@@ -1,0 +1,102 @@
+const REASONS = [
+  { id: "liked", label: "赞", category: "Positive Signal" },
+  { id: "story_not_engaging", label: "故事不好看", category: "Story Review" },
+  { id: "character_wrong", label: "人物不像 / 情绪不对", category: "Story Review" },
+  { id: "chinese_too_hard", label: "中文太难", category: "Readability" },
+  { id: "comic_confusing", label: "漫画看不懂", category: "Comic QA" },
+  { id: "image_quality", label: "图片质量有问题", category: "Comic QA" },
+  { id: "other", label: "其他", category: "Manual Triage" },
+] as const;
+
+const REASON_IDS = new Set<string>(REASONS.map((r) => r.id));
+
+const REASON_MAP = new Map<string, (typeof REASONS)[number]>(REASONS.map((r) => [r.id, r]));
+
+const MODES = new Set(["text", "comic"]);
+
+type Body = {
+  bookId?: string;
+  chapterId?: string;
+  passageId?: string;
+  mode?: string;
+  reason?: string;
+  detail?: string;
+  website?: string; // honeypot
+};
+
+export async function POST(request: Request): Promise<Response> {
+  let body: Body;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  // Honeypot — if filled, silently accept
+  if (body.website) {
+    return Response.json({ ok: true });
+  }
+
+  const bookId = (body.bookId ?? "").trim();
+  const chapterId = (body.chapterId ?? "").trim();
+  const passageId = (body.passageId ?? "").trim();
+  const mode = (body.mode ?? "").trim();
+  const reason = (body.reason ?? "").trim();
+  const detail = (body.detail ?? "").trim();
+
+  if (!bookId || !chapterId || !passageId) {
+    return Response.json({ error: "Missing passage path." }, { status: 422 });
+  }
+
+  if (!MODES.has(mode)) {
+    return Response.json({ error: "Invalid mode." }, { status: 422 });
+  }
+
+  const reasonEntry = REASON_MAP.get(reason);
+  if (!reasonEntry) {
+    return Response.json({ error: "Invalid reason." }, { status: 422 });
+  }
+
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+
+  if (webhookUrl) {
+    try {
+      const detailBlock = detail
+        ? [{ type: "section", text: { type: "mrkdwn", text: `*Detail:*\n${detail}` } }]
+        : [];
+
+      await fetch(webhookUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          text: `📝 Passage feedback: *${reasonEntry.label}* [${reasonEntry.category}] — ${bookId}/${chapterId}/${passageId} (${mode})`,
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: `📝 *Passage feedback*`,
+              },
+            },
+            {
+              type: "section",
+              fields: [
+                { type: "mrkdwn", text: `*Passage:*\n${bookId}/${chapterId}/${passageId}` },
+                { type: "mrkdwn", text: `*Mode:*\n${mode}` },
+                { type: "mrkdwn", text: `*Reason:*\n${reasonEntry.label}` },
+                { type: "mrkdwn", text: `*Category:*\n${reasonEntry.category}` },
+                { type: "mrkdwn", text: `*Source:*\n${request.headers.get("referer") ?? "unknown"}` },
+                { type: "mrkdwn", text: `*Time:*\n${new Date().toISOString()}` },
+              ],
+            },
+            ...detailBlock,
+          ],
+        }),
+      });
+    } catch {
+      console.error("Failed to send Slack notification");
+    }
+  }
+
+  return Response.json({ ok: true });
+}

--- a/site/app/globals.css
+++ b/site/app/globals.css
@@ -445,6 +445,146 @@ div {
   margin-top: 18px;
 }
 
+/* ── Passage feedback ── */
+
+.passage-feedback {
+  margin-top: 40px;
+  padding-top: 24px;
+  border-top: 1px solid var(--border-soft);
+}
+
+.passage-feedback-disclosure {
+  font-family: "SF Pro Text", "PingFang SC", "Noto Sans CJK SC", system-ui, sans-serif;
+  font-size: 0.8125rem;
+  color: var(--ink-muted);
+  margin: 0;
+  line-height: 1.5;
+}
+
+.passage-feedback-toggle {
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 0;
+  font-family: "SF Pro Text", "PingFang SC", "Noto Sans CJK SC", system-ui, sans-serif;
+  font-size: 0.8125rem;
+  color: var(--ink-soft);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.passage-feedback-toggle:hover {
+  color: var(--accent);
+}
+
+.passage-feedback-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-top: 10px;
+}
+
+.passage-feedback-like {
+  appearance: none;
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 14px;
+  font-family: "SF Pro Text", "PingFang SC", "Noto Sans CJK SC", system-ui, sans-serif;
+  font-size: 0.8125rem;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.passage-feedback-like:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(201, 100, 66, 0.06);
+}
+
+.passage-feedback-prompt {
+  font-family: "SF Pro Text", "PingFang SC", "Noto Sans CJK SC", system-ui, sans-serif;
+  font-size: 0.875rem;
+  color: var(--ink-soft);
+  margin: 14px 0 10px;
+}
+
+.passage-feedback-reasons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.passage-feedback-reason {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-family: "SF Pro Text", "PingFang SC", "Noto Sans CJK SC", system-ui, sans-serif;
+  font-size: 0.8125rem;
+  color: var(--ink-soft);
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.passage-feedback-reason:hover {
+  border-color: var(--ink-muted);
+}
+
+.passage-feedback-reason-selected {
+  border-color: var(--accent);
+  background: rgba(201, 100, 66, 0.08);
+  color: var(--accent);
+}
+
+.passage-feedback-detail {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--surface-strong);
+  font-family: "SF Pro Text", "PingFang SC", "Noto Sans CJK SC", system-ui, sans-serif;
+  font-size: 0.8125rem;
+  color: var(--ink);
+  resize: vertical;
+  line-height: 1.5;
+}
+
+.passage-feedback-detail::placeholder {
+  color: var(--ink-muted);
+}
+
+.passage-feedback-detail:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.passage-feedback-submit {
+  margin-top: 14px;
+  font-size: 0.8125rem;
+  padding: 6px 18px;
+}
+
+.passage-feedback-error {
+  font-family: "SF Pro Text", "PingFang SC", "Noto Sans CJK SC", system-ui, sans-serif;
+  font-size: 0.8125rem;
+  color: var(--accent);
+  margin: 8px 0 0;
+}
+
+.passage-feedback-success {
+  font-family: "SF Pro Text", "PingFang SC", "Noto Sans CJK SC", system-ui, sans-serif;
+  font-size: 0.8125rem;
+  color: var(--ink-muted);
+  margin: 10px 0 0;
+}
+
 .passage-image-shell-actionable {
   cursor: zoom-in;
 }

--- a/site/app/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
+++ b/site/app/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ComicImageBlock } from "@/components/comic-image-block";
 import { ModeHeader } from "@/components/mode-header";
+import { PassageFeedback } from "@/components/passage-feedback";
 import { getAllBooks, getBookById, getChapterById, getPassageBySlugs } from "@/lib/content";
 import { buildBookHref, buildChapterHref, buildPassageHref } from "@/lib/paths";
 
@@ -82,6 +83,8 @@ export default async function PassageComicPage({ params }: ComicPageProps) {
               passageHref={buildPassageHref({ bookId, chapterId, passageId })}
               routeParams={{ bookId, chapterId, passageId }}
             />
+
+            <PassageFeedback mode="comic" passagePath={{ bookId, chapterId, passageId }} />
           </article>
         </div>
       </section>

--- a/site/app/read/[bookId]/[chapterId]/[passageId]/page.tsx
+++ b/site/app/read/[bookId]/[chapterId]/[passageId]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { ComicImageBlock } from "@/components/comic-image-block";
 import { ModeHeader } from "@/components/mode-header";
+import { PassageFeedback } from "@/components/passage-feedback";
 import { PassageSceneFocus } from "@/components/passage-scene-focus";
 import { ReadingBookmarkSync } from "@/components/reading-bookmark-sync";
 import { proseToHtml } from "@/lib/format";
@@ -122,6 +123,8 @@ export default async function PassagePage({ params }: PassagePageProps) {
                 <div className="reading-body" dangerouslySetInnerHTML={{ __html: proseToHtml(passage.reading.text) }} />
               )}
             </div>
+
+            <PassageFeedback mode="text" passagePath={{ bookId, chapterId, passageId }} />
 
             <div className="passage-footer-nav">
               {previousPassage ? (

--- a/site/components/passage-feedback.tsx
+++ b/site/components/passage-feedback.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useEffect, type FormEvent } from "react";
+
+const NEGATIVE_REASONS = [
+  { id: "story_not_engaging", label: "故事不好看" },
+  { id: "character_wrong", label: "人物不像 / 情绪不对" },
+  { id: "chinese_too_hard", label: "中文太难" },
+  { id: "comic_confusing", label: "漫画看不懂" },
+  { id: "image_quality", label: "图片质量有问题" },
+  { id: "other", label: "其他" },
+] as const;
+
+const CACHE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+type Props = {
+  mode: "text" | "comic";
+  passagePath: { bookId: string; chapterId: string; passageId: string };
+};
+
+type Status = "idle" | "expanded" | "submitting" | "success" | "error";
+
+function cacheKey(path: Props["passagePath"], mode: string): string {
+  return `passage-feedback-${path.bookId}-${path.chapterId}-${path.passageId}-${mode}`;
+}
+
+function isCached(path: Props["passagePath"], mode: string): boolean {
+  try {
+    const raw = localStorage.getItem(cacheKey(path, mode));
+    if (!raw) return false;
+    return Date.now() < Number(raw);
+  } catch {
+    return false;
+  }
+}
+
+async function submitFeedback(
+  passagePath: Props["passagePath"],
+  mode: string,
+  reason: string,
+  detail?: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch("/api/passage-feedback", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ...passagePath, mode, reason, detail }),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      return { ok: false, error: data.error || "提交失败，请稍后再试。" };
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, error: "网络错误，请稍后再试。" };
+  }
+}
+
+function cacheSubmit(path: Props["passagePath"], mode: string) {
+  try {
+    localStorage.setItem(cacheKey(path, mode), String(Date.now() + CACHE_MS));
+  } catch {}
+}
+
+export function PassageFeedback({ mode, passagePath }: Props) {
+  const [status, setStatus] = useState<Status>("idle");
+  const [selectedReason, setSelectedReason] = useState("");
+  const [detail, setDetail] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    if (isCached(passagePath, mode)) {
+      setStatus("success");
+    }
+  }, [passagePath, mode]);
+
+  async function handleLike() {
+    setStatus("submitting");
+    const result = await submitFeedback(passagePath, mode, "liked");
+    if (result.ok) {
+      cacheSubmit(passagePath, mode);
+      setStatus("success");
+    } else {
+      setErrorMessage(result.error || "提交失败。");
+      setStatus("error");
+    }
+  }
+
+  function handleExpand() {
+    setStatus("expanded");
+  }
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setErrorMessage("");
+
+    if (!selectedReason) {
+      setErrorMessage("请选择一个问题。");
+      return;
+    }
+
+    setStatus("submitting");
+    const detailValue = selectedReason === "other" ? detail.trim() : undefined;
+    const result = await submitFeedback(passagePath, mode, selectedReason, detailValue);
+    if (result.ok) {
+      cacheSubmit(passagePath, mode);
+      setStatus("success");
+    } else {
+      setErrorMessage(result.error || "提交失败。");
+      setStatus("error");
+    }
+  }
+
+  return (
+    <div className="passage-feedback">
+      <p className="passage-feedback-disclosure">
+        本文和漫画由 AI 辅助生成，并经过编辑流程整理。
+      </p>
+
+      {status === "idle" && (
+        <div className="passage-feedback-actions">
+          <button
+            type="button"
+            className="passage-feedback-like"
+            onClick={handleLike}
+          >
+            赞一下
+          </button>
+          <button
+            type="button"
+            className="passage-feedback-toggle"
+            onClick={handleExpand}
+          >
+            有问题？告诉我们
+          </button>
+        </div>
+      )}
+
+      {status === "expanded" || status === "submitting" || status === "error" ? (
+        <form onSubmit={handleSubmit} noValidate>
+          <p className="passage-feedback-prompt">你觉得哪里有问题？</p>
+          <div className="passage-feedback-reasons">
+            {NEGATIVE_REASONS.map((r) => (
+              <label
+                key={r.id}
+                className={`passage-feedback-reason ${selectedReason === r.id ? "passage-feedback-reason-selected" : ""}`}
+              >
+                <input
+                  type="radio"
+                  name="reason"
+                  value={r.id}
+                  checked={selectedReason === r.id}
+                  onChange={() => { setSelectedReason(r.id); if (r.id !== "other") setDetail(""); }}
+                  className="visually-hidden"
+                />
+                {r.label}
+              </label>
+            ))}
+          </div>
+
+          {selectedReason === "other" && (
+            <textarea
+              className="passage-feedback-detail"
+              value={detail}
+              onChange={(e) => setDetail(e.target.value)}
+              placeholder="请描述一下具体问题…"
+              rows={2}
+            />
+          )}
+
+          <button
+            type="submit"
+            className="button-link button-link-secondary passage-feedback-submit"
+            disabled={status === "submitting"}
+          >
+            {status === "submitting" ? "提交中…" : "提交反馈"}
+          </button>
+
+          {errorMessage && (
+            <p className="passage-feedback-error">{errorMessage}</p>
+          )}
+        </form>
+      ) : null}
+
+      {status === "success" && (
+        <p className="passage-feedback-success">感谢反馈！</p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add AI-generated content disclosure to passage text and comic pages
- Add feedback UI: thumbs-up (liked) button + expandable reason selector
- "Other" reason includes free-text detail input
- New API endpoint `/api/passage-feedback` with reason-to-category mapping and Slack notification
- localStorage 7-day cache prevents duplicate submissions per passage+mode

Closes #16

## Test plan
- [x] `npm run build` passes
- [ ] Verify disclosure text appears on text passage page
- [ ] Verify disclosure text appears on comic passage page
- [ ] Click "赞一下" → success state, Slack receives notification
- [ ] Click "有问题？告诉我们" → reason pills appear
- [ ] Select a reason + submit → success state, Slack receives notification
- [ ] Select "其他" → textarea appears, detail included in Slack
- [ ] Refresh page → no longer shows feedback form (cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)