### PR TITLE
Add i18n system with zh/en locale routing and auto-detection

### DIFF
--- a/site/app/[locale]/page.tsx
+++ b/site/app/[locale]/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import { SiteFooter } from "@/components/site-footer";
+import { getDictionary } from "@/i18n";
+import type { Locale } from "@/lib/types";
+
+const VALID_LOCALES: Locale[] = ["zh", "en"];
+
+type LocaleHomePageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateStaticParams() {
+  return VALID_LOCALES.map((locale) => ({ locale }));
+}
+
+export default async function LocaleHomePage({ params }: LocaleHomePageProps) {
+  const { locale } = await params;
+  const safeLocale = VALID_LOCALES.includes(locale as Locale) ? (locale as Locale) : "zh";
+  const t = getDictionary(safeLocale);
+
+  return (
+    <div className="page-shell home-hero-page">
+      <main>
+        <section className="home-hero">
+          <div className="container home-hero-inner">
+            <h1 className="home-hero-title">{t.landing.heroTitle}</h1>
+            <div className="home-hero-actions">
+              <Link className="button-link button-link-accent home-hero-cta" href={`/${safeLocale}/read`}>
+                {t.landing.cta}
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+      <SiteFooter locale={safeLocale} />
+    </div>
+  );
+}

--- a/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
+++ b/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { ComicImageBlock } from "@/components/comic-image-block";
 import { ModeHeader } from "@/components/mode-header";
 import { PassageFeedback } from "@/components/passage-feedback";
+import { getDictionary } from "@/i18n";
 import { getAllBooks, getBookById, getChapterById, getPassageBySlugs } from "@/lib/content";
 import { buildBookHref, buildChapterHref, buildPassageHref } from "@/lib/paths";
 import type { Locale } from "@/lib/types";
@@ -47,6 +48,7 @@ export async function generateStaticParams() {
 export default async function LocaleComicPage({ params }: LocaleComicPageProps) {
   const { locale, bookId, chapterId, passageId } = await params;
   const safeLocale = VALID_LOCALES.includes(locale as Locale) ? (locale as Locale) : "zh";
+  const t = getDictionary(safeLocale);
 
   const [book, chapter, passage] = await Promise.all([
     getBookById(bookId),
@@ -70,7 +72,7 @@ export default async function LocaleComicPage({ params }: LocaleComicPageProps) 
         passageLabel={passage.title}
         compactTitle={passage.title}
         primaryLink={{ label: bookTitle, href: buildBookHref(book.id, safeLocale) }}
-        actionLink={{ label: isEn ? "Text" : "正文", href: buildPassageHref({ bookId, chapterId, passageId }, safeLocale) }}
+        actionLink={{ label: t.common.text, href: buildPassageHref({ bookId, chapterId, passageId }, safeLocale) }}
         secondaryLink={{ label: chapterLabel, href: buildChapterHref(book.id, chapter.id, safeLocale) }}
       />
 
@@ -80,14 +82,14 @@ export default async function LocaleComicPage({ params }: LocaleComicPageProps) 
             <p className="eyebrow">{bookTitle}</p>
             <h1 className="section-title passage-page-title">{passage.title}</h1>
             <p className="section-copy">
-              {isEn ? "Read this passage in comic mode, switch to text anytime." : "用漫画模式阅读这一节，需要时再随时回到正文。"}
+              {t.comic.description}
             </p>
             <div className="reader-card-actions">
               <Link className="button-link" href={buildPassageHref({ bookId, chapterId, passageId }, safeLocale)}>
-                {isEn ? "Back to text" : "返回正文"}
+                {t.common.backToText}
               </Link>
               <Link className="button-link button-link-accent" href={buildChapterHref(bookId, chapterId, safeLocale)}>
-                {isEn ? "Back to chapter" : "返回章节"}
+                {t.common.backToChapter}
               </Link>
             </div>
 
@@ -98,7 +100,7 @@ export default async function LocaleComicPage({ params }: LocaleComicPageProps) 
               routeParams={{ bookId, chapterId, passageId }}
             />
 
-            <PassageFeedback mode="comic" passagePath={{ bookId, chapterId, passageId }} />
+            <PassageFeedback mode="comic" passagePath={{ bookId, chapterId, passageId }} locale={safeLocale} />
           </article>
         </div>
       </section>

--- a/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/page.tsx
+++ b/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/page.tsx
@@ -7,6 +7,7 @@ import { ModeHeader } from "@/components/mode-header";
 import { PassageFeedback } from "@/components/passage-feedback";
 import { PassageSceneFocus } from "@/components/passage-scene-focus";
 import { ReadingBookmarkSync } from "@/components/reading-bookmark-sync";
+import { getDictionary } from "@/i18n";
 import { getAllBooks, getBookById, getChapterById, getPassageBySlugs } from "@/lib/content";
 import { proseToHtml } from "@/lib/format";
 import { resolveLocalizedPassage } from "@/lib/locale";
@@ -53,6 +54,7 @@ export async function generateStaticParams() {
 export default async function LocalePassagePage({ params }: LocalePassagePageProps) {
   const { locale, bookId, chapterId, passageId } = await params;
   const safeLocale = VALID_LOCALES.includes(locale as Locale) ? (locale as Locale) : "zh";
+  const t = getDictionary(safeLocale);
 
   const [book, chapter, passage] = await Promise.all([
     getBookById(bookId),
@@ -81,9 +83,9 @@ export default async function LocalePassagePage({ params }: LocalePassagePagePro
           <div className="container passage-single-column">
             <article className="passage-main reader-card">
               <h1 className="section-title passage-page-title">{passage.title}</h1>
-              <p className="body-copy">This passage is not yet available in {safeLocale === "en" ? "English" : "Chinese"}.</p>
+              <p className="body-copy">{t.locale.passageUnavailable.replace("{locale}", safeLocale === "en" ? "English" : "中文")}</p>
               <Link className="button-link button-link-accent" href={buildPassageHref({ bookId, chapterId, passageId }, "zh")}>
-                Read in Chinese
+                {t.locale.readInOther}
               </Link>
             </article>
           </div>
@@ -111,7 +113,7 @@ export default async function LocalePassagePage({ params }: LocalePassagePagePro
         passageLabel={localized.title}
         compactTitle={localized.title}
         primaryLink={{ label: bookTitle, href: buildBookHref(book.id, safeLocale) }}
-        actionLink={{ label: isEn ? "Comic" : "漫画", href: buildComicHref(routeParams, safeLocale) }}
+        actionLink={{ label: t.common.comic, href: buildComicHref(routeParams, safeLocale) }}
         secondaryLink={{ label: chapterLabel, href: buildChapterHref(book.id, chapter.id, safeLocale) }}
       />
 
@@ -173,7 +175,7 @@ export default async function LocalePassagePage({ params }: LocalePassagePagePro
               )}
             </div>
 
-            <PassageFeedback mode="text" passagePath={{ bookId, chapterId, passageId }} />
+            <PassageFeedback mode="text" passagePath={{ bookId, chapterId, passageId }} locale={safeLocale} />
 
             <div className="passage-footer-nav">
               {previousPassage ? (
@@ -181,11 +183,11 @@ export default async function LocalePassagePage({ params }: LocalePassagePagePro
                   className="text-nav-link"
                   href={buildPassageHref({ bookId, chapterId, passageId: previousPassage.passage_id }, safeLocale)}
                 >
-                  {isEn ? "Previous" : "上一节"}
+                  {t.common.previous}
                 </Link>
               ) : (
                 <Link className="text-nav-link" href={buildChapterHref(bookId, chapterId, safeLocale)}>
-                  {isEn ? "Back to chapter" : "返回章节"}
+                  {t.common.backToChapter}
                 </Link>
               )}
               {nextPassage ? (
@@ -193,7 +195,7 @@ export default async function LocalePassagePage({ params }: LocalePassagePagePro
                   className="button-link button-link-accent"
                   href={buildPassageHref({ bookId, chapterId, passageId: nextPassage.passage_id }, safeLocale)}
                 >
-                  {isEn ? "Next" : "下一节"}
+                  {t.common.next}
                 </Link>
               ) : null}
             </div>

--- a/site/app/[locale]/read/[bookId]/[chapterId]/page.tsx
+++ b/site/app/[locale]/read/[bookId]/[chapterId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ModeHeader } from "@/components/mode-header";
+import { getDictionary } from "@/i18n";
 import { formatChapterTitle } from "@/lib/chapter-title";
 import { getAllBooks, getBookById, getChapterById } from "@/lib/content";
 import { buildComicHref, buildPassageHref } from "@/lib/paths";
@@ -37,6 +38,7 @@ export async function generateStaticParams() {
 export default async function LocaleChapterPage({ params }: LocaleChapterPageProps) {
   const { locale, bookId, chapterId } = await params;
   const safeLocale = VALID_LOCALES.includes(locale as Locale) ? (locale as Locale) : "zh";
+  const t = getDictionary(safeLocale);
 
   const [book, chapter] = await Promise.all([getBookById(bookId), getChapterById(bookId, chapterId)]);
 
@@ -81,13 +83,13 @@ export default async function LocaleChapterPage({ params }: LocaleChapterPagePro
                     className="button-link button-link-accent"
                     href={buildPassageHref({ bookId, chapterId, passageId: passage.passage_id }, safeLocale)}
                   >
-                    正文
+                    {t.common.text}
                   </Link>
                   <Link
                     className="button-link button-link-secondary"
                     href={buildComicHref({ bookId, chapterId, passageId: passage.passage_id }, safeLocale)}
                   >
-                    漫画
+                    {t.common.comic}
                   </Link>
                 </div>
               </article>

--- a/site/app/[locale]/read/[bookId]/page.tsx
+++ b/site/app/[locale]/read/[bookId]/page.tsx
@@ -37,6 +37,8 @@ export default async function LocaleBookPage({ params }: LocaleBookPageProps) {
   const chapters = (
     await Promise.all(chapterSummaries.map((chapter) => getChapterById(book.id, chapter.id)))
   ).filter((chapter): chapter is NonNullable<Awaited<ReturnType<typeof getChapterById>>> => Boolean(chapter));
+  const isEn = safeLocale === "en";
+
   const readerChapters: ReaderChapter[] = chapters.map((chapter) => ({
     id: chapter.id,
     source_title: chapter.source_title,
@@ -46,12 +48,10 @@ export default async function LocaleBookPage({ params }: LocaleBookPageProps) {
       passage_id: passage.passage_id,
       title: passage.title,
       title_en: passage.title_en,
-      catchup: passage.catchup_en ?? passage.catchup,
+      catchup: isEn && passage.catchup_en ? passage.catchup_en : passage.catchup,
       available_locales: passage.available_locales,
     })),
   }));
-
-  const isEn = safeLocale === "en";
   const bookTitle = isEn && book.title_en ? book.title_en : book.title;
   const bookSubtitle = isEn && book.subtitle_en ? book.subtitle_en : book.subtitle;
 

--- a/site/app/[locale]/read/page.tsx
+++ b/site/app/[locale]/read/page.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import { ModeHeader } from "@/components/mode-header";
+import { SiteFooter } from "@/components/site-footer";
+import { FutureBookForm } from "@/components/future-book-form";
+import { getDictionary } from "@/i18n";
+import { getAllBooks } from "@/lib/content";
+import { buildBookHref } from "@/lib/paths";
+import type { Locale } from "@/lib/types";
+
+const VALID_LOCALES: Locale[] = ["zh", "en"];
+
+type LocaleReadIndexPageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateStaticParams() {
+  return VALID_LOCALES.map((locale) => ({ locale }));
+}
+
+export default async function LocaleReadIndexPage({ params }: LocaleReadIndexPageProps) {
+  const { locale } = await params;
+  const safeLocale = VALID_LOCALES.includes(locale as Locale) ? (locale as Locale) : "zh";
+  const books = await getAllBooks();
+  const t = getDictionary(safeLocale);
+  const isEn = safeLocale === "en";
+
+  return (
+    <div className="page-shell reader-page">
+      <main>
+        <ModeHeader compactTitle={t.read.pageTitle} bookLabel={t.read.pageTitle} locale={safeLocale} />
+
+        <section className="section">
+          <div className="container section-head read-index-head">
+            <div>
+              <h1 className="section-title">{t.read.pageTitle}</h1>
+            </div>
+          </div>
+        </section>
+
+        <section className="section">
+          <div className="container reader-stack">
+            {books.map((book) => {
+              const bookTitle = isEn && book.title_en ? book.title_en : book.title;
+              const bookSubtitle = isEn && book.subtitle_en ? book.subtitle_en : book.subtitle;
+
+              return (
+                <article className="reader-card read-book-card" key={book.id}>
+                  <div>
+                    <h2 className="passage-title">{bookTitle}</h2>
+                    {bookSubtitle ? <p className="body-copy">{bookSubtitle}</p> : null}
+                  </div>
+                  <div className="read-book-side">
+                    <Link className="button-link button-link-accent" href={buildBookHref(book.id, safeLocale)}>
+                      {t.read.openBook}
+                    </Link>
+                  </div>
+                </article>
+              );
+            })}
+
+            <FutureBookForm locale={safeLocale} />
+          </div>
+        </section>
+      </main>
+      <SiteFooter locale={safeLocale} />
+    </div>
+  );
+}

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,22 +1,25 @@
 import Link from "next/link";
 import { SiteFooter } from "@/components/site-footer";
+import { getDictionary } from "@/i18n";
 
 export default async function HomePage() {
+  const t = getDictionary("zh");
+
   return (
     <div className="page-shell home-hero-page">
       <main>
         <section className="home-hero">
           <div className="container home-hero-inner">
-            <h1 className="home-hero-title">让中国经典更加生动</h1>
+            <h1 className="home-hero-title">{t.landing.heroTitle}</h1>
             <div className="home-hero-actions">
               <Link className="button-link button-link-accent home-hero-cta" href="/read">
-                Start Reading 《三国演义》
+                {t.landing.cta}
               </Link>
             </div>
           </div>
         </section>
       </main>
-      <SiteFooter />
+      <SiteFooter locale="zh" />
     </div>
   );
 }

--- a/site/app/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
+++ b/site/app/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { ComicImageBlock } from "@/components/comic-image-block";
 import { ModeHeader } from "@/components/mode-header";
 import { PassageFeedback } from "@/components/passage-feedback";
+import { getDictionary } from "@/i18n";
 import { getAllBooks, getBookById, getChapterById, getPassageBySlugs } from "@/lib/content";
 import { buildBookHref, buildChapterHref, buildPassageHref } from "@/lib/paths";
 
@@ -39,6 +40,7 @@ export async function generateStaticParams() {
 
 export default async function PassageComicPage({ params }: ComicPageProps) {
   const { bookId, chapterId, passageId } = await params;
+  const t = getDictionary("zh");
   const [book, chapter, passage] = await Promise.all([
     getBookById(bookId),
     getChapterById(bookId, chapterId),
@@ -57,7 +59,7 @@ export default async function PassageComicPage({ params }: ComicPageProps) {
         passageLabel={passage.title}
         compactTitle={passage.title}
         primaryLink={{ label: book.title, href: buildBookHref(book.id) }}
-        actionLink={{ label: "正文", href: buildPassageHref({ bookId, chapterId, passageId }) }}
+        actionLink={{ label: t.common.text, href: buildPassageHref({ bookId, chapterId, passageId }) }}
         secondaryLink={{ label: chapter.adapted_title_cn || chapter.source_title, href: buildChapterHref(book.id, chapter.id) }}
       />
 
@@ -67,14 +69,14 @@ export default async function PassageComicPage({ params }: ComicPageProps) {
             <p className="eyebrow">{book.title}</p>
             <h1 className="section-title passage-page-title">{passage.title}</h1>
             <p className="section-copy">
-              用漫画模式阅读这一节，需要时再随时回到正文。
+              {t.comic.description}
             </p>
             <div className="reader-card-actions">
               <Link className="button-link" href={buildPassageHref({ bookId, chapterId, passageId })}>
-                返回正文
+                {t.common.backToText}
               </Link>
               <Link className="button-link button-link-accent" href={buildChapterHref(bookId, chapterId)}>
-                返回章节
+                {t.common.backToChapter}
               </Link>
             </div>
 
@@ -84,7 +86,7 @@ export default async function PassageComicPage({ params }: ComicPageProps) {
               routeParams={{ bookId, chapterId, passageId }}
             />
 
-            <PassageFeedback mode="comic" passagePath={{ bookId, chapterId, passageId }} />
+            <PassageFeedback mode="comic" passagePath={{ bookId, chapterId, passageId }} locale="zh" />
           </article>
         </div>
       </section>

--- a/site/app/read/[bookId]/[chapterId]/[passageId]/page.tsx
+++ b/site/app/read/[bookId]/[chapterId]/[passageId]/page.tsx
@@ -6,6 +6,7 @@ import { ModeHeader } from "@/components/mode-header";
 import { PassageFeedback } from "@/components/passage-feedback";
 import { PassageSceneFocus } from "@/components/passage-scene-focus";
 import { ReadingBookmarkSync } from "@/components/reading-bookmark-sync";
+import { getDictionary } from "@/i18n";
 import { proseToHtml } from "@/lib/format";
 import { getAllBooks, getBookById, getChapterById, getPassageBySlugs } from "@/lib/content";
 import { buildBookHref, buildChapterHref, buildComicHref, buildPassageHref } from "@/lib/paths";
@@ -43,6 +44,7 @@ export async function generateStaticParams() {
 
 export default async function PassagePage({ params }: PassagePageProps) {
   const { bookId, chapterId, passageId } = await params;
+  const t = getDictionary("zh");
   const [book, chapter, passage] = await Promise.all([
     getBookById(bookId),
     getChapterById(bookId, chapterId),
@@ -70,7 +72,7 @@ export default async function PassagePage({ params }: PassagePageProps) {
         passageLabel={passage.title}
         compactTitle={passage.title}
         primaryLink={{ label: book.title, href: buildBookHref(book.id) }}
-        actionLink={{ label: "漫画", href: buildComicHref({ bookId, chapterId, passageId }) }}
+        actionLink={{ label: t.common.comic, href: buildComicHref({ bookId, chapterId, passageId }) }}
         secondaryLink={{ label: chapter.adapted_title_cn || chapter.source_title, href: buildChapterHref(book.id, chapter.id) }}
       />
 
@@ -124,7 +126,7 @@ export default async function PassagePage({ params }: PassagePageProps) {
               )}
             </div>
 
-            <PassageFeedback mode="text" passagePath={{ bookId, chapterId, passageId }} />
+            <PassageFeedback mode="text" passagePath={{ bookId, chapterId, passageId }} locale="zh" />
 
             <div className="passage-footer-nav">
               {previousPassage ? (
@@ -132,11 +134,11 @@ export default async function PassagePage({ params }: PassagePageProps) {
                   className="text-nav-link"
                   href={buildPassageHref({ bookId, chapterId, passageId: previousPassage.passage_id })}
                 >
-                  上一节
+                  {t.common.previous}
                 </Link>
               ) : (
                 <Link className="text-nav-link" href={buildChapterHref(bookId, chapterId)}>
-                  返回章节
+                  {t.common.backToChapter}
                 </Link>
               )}
               {nextPassage ? (
@@ -144,7 +146,7 @@ export default async function PassagePage({ params }: PassagePageProps) {
                   className="button-link button-link-accent"
                   href={buildPassageHref({ bookId, chapterId, passageId: nextPassage.passage_id })}
                 >
-                  下一节
+                  {t.common.next}
                 </Link>
               ) : null}
             </div>

--- a/site/app/read/[bookId]/[chapterId]/page.tsx
+++ b/site/app/read/[bookId]/[chapterId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { ModeHeader } from "@/components/mode-header";
+import { getDictionary } from "@/i18n";
 import { formatChapterTitle } from "@/lib/chapter-title";
 import { getAllBooks, getBookById, getChapterById } from "@/lib/content";
 import { buildComicHref, buildPassageHref } from "@/lib/paths";
@@ -29,6 +30,7 @@ export async function generateStaticParams() {
 
 export default async function ChapterPage({ params }: ChapterPageProps) {
   const { bookId, chapterId } = await params;
+  const t = getDictionary("zh");
   const [book, chapter] = await Promise.all([getBookById(bookId), getChapterById(bookId, chapterId)]);
 
   if (!book || !chapter) {
@@ -62,13 +64,13 @@ export default async function ChapterPage({ params }: ChapterPageProps) {
                   className="button-link button-link-accent"
                   href={buildPassageHref({ bookId, chapterId, passageId: passage.passage_id })}
                 >
-                  正文
+                  {t.common.text}
                 </Link>
                 <Link
                   className="button-link button-link-secondary"
                   href={buildComicHref({ bookId, chapterId, passageId: passage.passage_id })}
                 >
-                  漫画
+                  {t.common.comic}
                 </Link>
               </div>
             </article>

--- a/site/app/read/page.tsx
+++ b/site/app/read/page.tsx
@@ -2,21 +2,23 @@ import Link from "next/link";
 import { ModeHeader } from "@/components/mode-header";
 import { SiteFooter } from "@/components/site-footer";
 import { FutureBookForm } from "@/components/future-book-form";
+import { getDictionary } from "@/i18n";
 import { getAllBooks } from "@/lib/content";
 import { buildBookHref } from "@/lib/paths";
 
 export default async function ReadIndexPage() {
   const books = await getAllBooks();
+  const t = getDictionary("zh");
 
   return (
     <div className="page-shell reader-page">
       <main>
-        <ModeHeader compactTitle="Read Chinese Classics" bookLabel="Read Chinese Classics" />
+        <ModeHeader compactTitle={t.read.pageTitle} bookLabel={t.read.pageTitle} />
 
         <section className="section">
           <div className="container section-head read-index-head">
             <div>
-              <h1 className="section-title">Read Chinese Classics</h1>
+              <h1 className="section-title">{t.read.pageTitle}</h1>
             </div>
           </div>
         </section>
@@ -31,17 +33,17 @@ export default async function ReadIndexPage() {
                 </div>
                 <div className="read-book-side">
                   <Link className="button-link button-link-accent" href={buildBookHref(book.id)}>
-                    打开这本书
+                    {t.read.openBook}
                   </Link>
                 </div>
               </article>
             ))}
 
-            <FutureBookForm />
+            <FutureBookForm locale="zh" />
           </div>
         </section>
       </main>
-      <SiteFooter />
+      <SiteFooter locale="zh" />
     </div>
   );
 }

--- a/site/components/book-chapter-browser.tsx
+++ b/site/components/book-chapter-browser.tsx
@@ -2,7 +2,9 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
+import { getDictionary } from "@/i18n";
 import { formatChapterTitle } from "@/lib/chapter-title";
+import type { Locale } from "@/lib/types";
 import { buildComicHref, buildPassageHref } from "@/lib/paths";
 
 type ReadingBookmark = {
@@ -15,7 +17,7 @@ type ReadingBookmark = {
 type BookChapterBrowserProps = {
   bookId: string;
   chapters: ReaderChapter[];
-  locale?: string;
+  locale?: Locale;
 };
 
 const BOOKMARK_KEY_PREFIX = "reading-bookmark:";
@@ -40,8 +42,9 @@ function getBookmarkKey(bookId: string) {
   return `${BOOKMARK_KEY_PREFIX}${bookId}`;
 }
 
-export function BookChapterBrowser({ bookId, chapters, locale }: BookChapterBrowserProps) {
+export function BookChapterBrowser({ bookId, chapters, locale = "zh" }: BookChapterBrowserProps) {
   const isEn = locale === "en";
+  const t = getDictionary(locale);
   const [expandedChapterId, setExpandedChapterId] = useState<string | null>(chapters[0]?.id ?? null);
   const [bookmark, setBookmark] = useState<ReadingBookmark | null>(null);
 
@@ -87,10 +90,10 @@ export function BookChapterBrowser({ bookId, chapters, locale }: BookChapterBrow
         <section className="section">
           <div className="container">
             <article className="panel bookmark-panel">
-              <p className="eyebrow">阅读书签</p>
+              <p className="eyebrow">{t.bookmark.label}</p>
               <div className="bookmark-row">
                 <div>
-                  <h2 className="panel-title">{isEn ? "Continue reading" : "继续上次阅读"}</h2>
+                  <h2 className="panel-title">{t.bookmark.title}</h2>
                   <p className="body-copy">
                     {isEn && bookmarkLabel.passage.title_en ? bookmarkLabel.passage.title_en : bookmarkLabel.passage.title}
                   </p>
@@ -103,7 +106,7 @@ export function BookChapterBrowser({ bookId, chapters, locale }: BookChapterBrow
                     passageId: bookmarkLabel.passage.passage_id,
                   }, locale as "zh" | "en")}
                 >
-                  {isEn ? "Continue" : "继续阅读"}
+                  {t.bookmark.continue}
                 </Link>
               </div>
             </article>
@@ -131,7 +134,7 @@ export function BookChapterBrowser({ bookId, chapters, locale }: BookChapterBrow
                     <span className="chapter-meta-toggle" aria-hidden="true">
                       <span className={`chapter-toggle-icon ${isExpanded ? "chapter-toggle-icon-open" : ""}`} aria-hidden="true" />
                     </span>
-                    <span className="visually-hidden">{isExpanded ? "收起章节" : "展开章节"}</span>
+                    <span className="visually-hidden">{isExpanded ? t.chapter.collapse : t.chapter.expand}</span>
                   </div>
                 </button>
 
@@ -155,13 +158,13 @@ export function BookChapterBrowser({ bookId, chapters, locale }: BookChapterBrow
                                 className="button-link button-link-secondary"
                                 href={buildPassageHref({ bookId, chapterId: chapter.id, passageId: passage.passage_id }, locale as "zh" | "en")}
                               >
-                                {isEn ? "Text" : "正文"}
+                                {t.common.text}
                               </Link>
                               <Link
                                 className="button-link button-link-secondary"
                                 href={buildComicHref({ bookId, chapterId: chapter.id, passageId: passage.passage_id }, locale as "zh" | "en")}
                               >
-                                {isEn ? "Comic" : "漫画"}
+                                {t.common.comic}
                               </Link>
                             </div>
                           </article>

--- a/site/components/future-book-form.tsx
+++ b/site/components/future-book-form.tsx
@@ -1,16 +1,13 @@
 "use client";
 
 import { useState, useEffect, type FormEvent } from "react";
+import { getDictionary } from "@/i18n";
+import type { Locale } from "@/lib/types";
 
 const CACHE_KEY = "future-books-submitted";
 const CACHE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
-const BOOKS = [
-  { id: "xiyouji", label: "西游记" },
-  { id: "shuihu", label: "水浒传" },
-  { id: "hongloumeng", label: "红楼梦" },
-  { id: "jinpingmei", label: "金瓶梅" },
-] as const;
+const BOOK_IDS = ["xiyouji", "shuihu", "hongloumeng", "jinpingmei"] as const;
 
 type Status = "idle" | "submitting" | "success" | "error";
 
@@ -24,7 +21,8 @@ function isCached(): boolean {
   }
 }
 
-export function FutureBookForm() {
+export function FutureBookForm({ locale = "zh" }: { locale?: Locale }) {
+  const t = getDictionary(locale);
   const [visible, setVisible] = useState(false);
   const [selectedBook, setSelectedBook] = useState("");
   const [email, setEmail] = useState("");
@@ -40,13 +38,13 @@ export function FutureBookForm() {
     setErrorMessage("");
 
     if (!selectedBook) {
-      setErrorMessage("请选择一本书。");
+      setErrorMessage(t.futureBooks.selectBook);
       return;
     }
 
     const trimmed = email.trim();
     if (!trimmed || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
-      setErrorMessage("请输入有效的邮箱地址。");
+      setErrorMessage(t.futureBooks.invalidEmail);
       return;
     }
 
@@ -64,7 +62,7 @@ export function FutureBookForm() {
 
       if (!res.ok) {
         const data = await res.json();
-        setErrorMessage(data.error || "提交失败，请稍后再试。");
+        setErrorMessage(data.error || t.futureBooks.submitError);
         setStatus("error");
         return;
       }
@@ -75,7 +73,7 @@ export function FutureBookForm() {
 
       setStatus("success");
     } catch {
-      setErrorMessage("网络错误，请稍后再试。");
+      setErrorMessage(t.futureBooks.networkError);
       setStatus("error");
     }
   }
@@ -86,7 +84,7 @@ export function FutureBookForm() {
     return (
       <article className="reader-card future-books-card">
         <p className="future-books-success-text">
-          收到了！我们会在你选的书可读时通知你。
+          {t.futureBooks.success}
         </p>
       </article>
     );
@@ -95,27 +93,27 @@ export function FutureBookForm() {
   return (
     <article className="reader-card future-books-card">
       <div>
-        <h2 className="passage-title">下一本读什么？</h2>
-        <p className="body-copy">告诉我们你最想读的经典，开始制作时通知你。</p>
+        <h2 className="passage-title">{t.futureBooks.title}</h2>
+        <p className="body-copy">{t.futureBooks.description}</p>
       </div>
       <form onSubmit={handleSubmit} noValidate>
-        <p className="future-books-prompt">你最想读哪一本？</p>
+        <p className="future-books-prompt">{t.futureBooks.prompt}</p>
 
         <div className="book-option-grid">
-          {BOOKS.map((book) => (
+          {BOOK_IDS.map((id) => (
             <label
-              key={book.id}
-              className={`book-option-label ${selectedBook === book.id ? "book-option-selected" : ""}`}
+              key={id}
+              className={`book-option-label ${selectedBook === id ? "book-option-selected" : ""}`}
             >
               <input
                 type="radio"
                 name="book"
-                value={book.id}
-                checked={selectedBook === book.id}
-                onChange={() => setSelectedBook(book.id)}
+                value={id}
+                checked={selectedBook === id}
+                onChange={() => setSelectedBook(id)}
                 className="book-option-input"
               />
-              {book.label}
+              {t.futureBooks.books[id]}
             </label>
           ))}
         </div>
@@ -135,7 +133,7 @@ export function FutureBookForm() {
             className="button-link button-link-secondary future-books-submit"
             disabled={status === "submitting"}
           >
-            {status === "submitting" ? "提交中…" : "通知我"}
+            {status === "submitting" ? t.common.submitting : t.futureBooks.notify}
           </button>
         </div>
 
@@ -154,7 +152,7 @@ export function FutureBookForm() {
         )}
 
         <p className="future-books-privacy">
-          我们只会在这本书可读时通知你。
+          {t.futureBooks.privacy}
         </p>
       </form>
     </article>

--- a/site/components/mode-header.tsx
+++ b/site/components/mode-header.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import { getDictionary } from "@/i18n";
+import type { Locale } from "@/lib/types";
 
 function TextIcon({ className }: { className?: string }) {
   return (
@@ -67,6 +69,7 @@ type ModeHeaderProps = {
     label: string;
     href: string;
   };
+  locale?: Locale;
 };
 
 export function ModeHeader({
@@ -78,7 +81,9 @@ export function ModeHeader({
   primaryLink,
   secondaryLink,
   actionLink,
+  locale = "zh",
 }: ModeHeaderProps) {
+  const t = getDictionary(locale);
   const [isCompressed, setIsCompressed] = useState(false);
 
   useEffect(() => {
@@ -146,7 +151,7 @@ export function ModeHeader({
               href={actionLink.href}
               title={actionLink.label}
             >
-              {actionLink.label === "漫画" ? <ComicIcon /> : <TextIcon />}
+              {actionLink.label === t.common.comic ? <ComicIcon /> : <TextIcon />}
             </Link>
           ) : secondaryLink ? (
             <Link className="mode-link" href={secondaryLink.href}>
@@ -155,15 +160,15 @@ export function ModeHeader({
           ) : !isCompressed ? (
             <>
               <Link className="mode-link" href="/">
-                首页
+                {t.common.home}
               </Link>
               <Link className="mode-link" href="/read">
-                书库
+                {t.common.library}
               </Link>
             </>
           ) : (
             <Link className="mode-link" href="/read">
-              全部书目
+              {t.common.allBooks}
             </Link>
           )}
         </nav>

--- a/site/components/passage-feedback.tsx
+++ b/site/components/passage-feedback.tsx
@@ -1,14 +1,16 @@
 "use client";
 
 import { useState, useEffect, type FormEvent } from "react";
+import { getDictionary } from "@/i18n";
+import type { Locale } from "@/lib/types";
 
-const NEGATIVE_REASONS = [
-  { id: "story_not_engaging", label: "故事不好看" },
-  { id: "character_wrong", label: "人物不像 / 情绪不对" },
-  { id: "chinese_too_hard", label: "中文太难" },
-  { id: "comic_confusing", label: "漫画看不懂" },
-  { id: "image_quality", label: "图片质量有问题" },
-  { id: "other", label: "其他" },
+const REASON_IDS = [
+  "story_not_engaging",
+  "character_wrong",
+  "chinese_too_hard",
+  "comic_confusing",
+  "image_quality",
+  "other",
 ] as const;
 
 const CACHE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
@@ -16,6 +18,7 @@ const CACHE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 type Props = {
   mode: "text" | "comic";
   passagePath: { bookId: string; chapterId: string; passageId: string };
+  locale?: Locale;
 };
 
 type Status = "idle" | "expanded" | "submitting" | "success" | "error";
@@ -49,11 +52,11 @@ async function submitFeedback(
 
     if (!res.ok) {
       const data = await res.json();
-      return { ok: false, error: data.error || "提交失败，请稍后再试。" };
+      return { ok: false, error: data.error };
     }
     return { ok: true };
   } catch {
-    return { ok: false, error: "网络错误，请稍后再试。" };
+    return { ok: false, error: "network" };
   }
 }
 
@@ -63,7 +66,8 @@ function cacheSubmit(path: Props["passagePath"], mode: string) {
   } catch {}
 }
 
-export function PassageFeedback({ mode, passagePath }: Props) {
+export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
+  const t = getDictionary(locale);
   const [status, setStatus] = useState<Status>("idle");
   const [selectedReason, setSelectedReason] = useState("");
   const [detail, setDetail] = useState("");
@@ -75,6 +79,11 @@ export function PassageFeedback({ mode, passagePath }: Props) {
     }
   }, [passagePath, mode]);
 
+  function resolveError(error?: string): string {
+    if (error === "network") return t.feedback.networkError;
+    return error || t.feedback.submitError;
+  }
+
   async function handleLike() {
     setStatus("submitting");
     const result = await submitFeedback(passagePath, mode, "liked");
@@ -82,7 +91,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
       cacheSubmit(passagePath, mode);
       setStatus("success");
     } else {
-      setErrorMessage(result.error || "提交失败。");
+      setErrorMessage(resolveError(result.error));
       setStatus("error");
     }
   }
@@ -96,7 +105,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
     setErrorMessage("");
 
     if (!selectedReason) {
-      setErrorMessage("请选择一个问题。");
+      setErrorMessage(t.feedback.selectReason);
       return;
     }
 
@@ -107,7 +116,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
       cacheSubmit(passagePath, mode);
       setStatus("success");
     } else {
-      setErrorMessage(result.error || "提交失败。");
+      setErrorMessage(resolveError(result.error));
       setStatus("error");
     }
   }
@@ -115,7 +124,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
   return (
     <div className="passage-feedback">
       <p className="passage-feedback-disclosure">
-        本文和漫画由 AI 辅助生成，并经过编辑流程整理。
+        {t.feedback.disclosure}
       </p>
 
       {status === "idle" && (
@@ -125,36 +134,36 @@ export function PassageFeedback({ mode, passagePath }: Props) {
             className="passage-feedback-like"
             onClick={handleLike}
           >
-            赞一下
+            {t.feedback.like}
           </button>
           <button
             type="button"
             className="passage-feedback-toggle"
             onClick={handleExpand}
           >
-            有问题？告诉我们
+            {t.feedback.report}
           </button>
         </div>
       )}
 
       {status === "expanded" || status === "submitting" || status === "error" ? (
         <form onSubmit={handleSubmit} noValidate>
-          <p className="passage-feedback-prompt">你觉得哪里有问题？</p>
+          <p className="passage-feedback-prompt">{t.feedback.prompt}</p>
           <div className="passage-feedback-reasons">
-            {NEGATIVE_REASONS.map((r) => (
+            {REASON_IDS.map((id) => (
               <label
-                key={r.id}
-                className={`passage-feedback-reason ${selectedReason === r.id ? "passage-feedback-reason-selected" : ""}`}
+                key={id}
+                className={`passage-feedback-reason ${selectedReason === id ? "passage-feedback-reason-selected" : ""}`}
               >
                 <input
                   type="radio"
                   name="reason"
-                  value={r.id}
-                  checked={selectedReason === r.id}
-                  onChange={() => { setSelectedReason(r.id); if (r.id !== "other") setDetail(""); }}
+                  value={id}
+                  checked={selectedReason === id}
+                  onChange={() => { setSelectedReason(id); if (id !== "other") setDetail(""); }}
                   className="visually-hidden"
                 />
-                {r.label}
+                {t.feedback.reasons[id]}
               </label>
             ))}
           </div>
@@ -164,7 +173,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
               className="passage-feedback-detail"
               value={detail}
               onChange={(e) => setDetail(e.target.value)}
-              placeholder="请描述一下具体问题…"
+              placeholder={t.feedback.placeholder}
               rows={2}
             />
           )}
@@ -174,7 +183,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
             className="button-link button-link-secondary passage-feedback-submit"
             disabled={status === "submitting"}
           >
-            {status === "submitting" ? "提交中…" : "提交反馈"}
+            {status === "submitting" ? t.common.submitting : t.feedback.submit}
           </button>
 
           {errorMessage && (
@@ -184,7 +193,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
       ) : null}
 
       {status === "success" && (
-        <p className="passage-feedback-success">感谢反馈！</p>
+        <p className="passage-feedback-success">{t.feedback.success}</p>
       )}
     </div>
   );

--- a/site/components/site-footer.tsx
+++ b/site/components/site-footer.tsx
@@ -1,10 +1,22 @@
-export function SiteFooter() {
+import { LanguageSwitch } from "@/components/language-switch";
+import type { Locale } from "@/lib/types";
+
+type SiteFooterProps = {
+  locale?: Locale;
+};
+
+export function SiteFooter({ locale = "zh" }: SiteFooterProps) {
   return (
     <footer className="site-footer">
       <div className="container site-footer-inner">
         <span className="site-footer-trademark">
-          © {new Date().getFullYear()} Read Chinese Classics
+          &copy; {new Date().getFullYear()} Read Chinese Classics
         </span>
+        <LanguageSwitch
+          currentLocale={locale}
+          availableLocales={["zh", "en"]}
+          localeHrefs={{ zh: locale === "zh" ? "/" : "/zh", en: locale === "en" ? "/" : "/en" }}
+        />
       </div>
     </footer>
   );

--- a/site/i18n/index.ts
+++ b/site/i18n/index.ts
@@ -1,0 +1,11 @@
+import zh from "./locales/zh.json";
+import en from "./locales/en.json";
+import type { Locale } from "@/lib/types";
+
+export type Dictionary = typeof zh;
+
+const dictionaries: Record<Locale, Dictionary> = { zh, en };
+
+export function getDictionary(locale: Locale): Dictionary {
+  return dictionaries[locale] ?? dictionaries.zh;
+}

--- a/site/i18n/locales/en.json
+++ b/site/i18n/locales/en.json
@@ -1,0 +1,77 @@
+{
+  "common": {
+    "home": "Home",
+    "library": "Library",
+    "allBooks": "All Books",
+    "text": "Text",
+    "comic": "Comic",
+    "previous": "Previous",
+    "next": "Next",
+    "backToChapter": "Back to chapter",
+    "backToText": "Back to text",
+    "submitting": "Submitting…",
+    "noContent": "No content yet."
+  },
+  "landing": {
+    "heroTitle": "Bringing Chinese Classics to Life",
+    "cta": "Start Reading Romance of the Three Kingdoms"
+  },
+  "read": {
+    "pageTitle": "Read Chinese Classics",
+    "openBook": "Open this book"
+  },
+  "bookmark": {
+    "label": "Reading Bookmark",
+    "title": "Continue reading",
+    "continue": "Continue"
+  },
+  "chapter": {
+    "collapse": "Collapse chapter",
+    "expand": "Expand chapter"
+  },
+  "comic": {
+    "description": "Read this passage in comic mode, switch to text anytime."
+  },
+  "feedback": {
+    "disclosure": "Text and comics are AI-assisted and edited by humans.",
+    "like": "Like",
+    "report": "Issue? Tell us",
+    "prompt": "What's the problem?",
+    "placeholder": "Describe the issue…",
+    "submit": "Submit feedback",
+    "success": "Thanks for your feedback!",
+    "submitError": "Submission failed. Please try again later.",
+    "networkError": "Network error. Please try again later.",
+    "selectReason": "Please select an issue.",
+    "reasons": {
+      "story_not_engaging": "Story not engaging",
+      "character_wrong": "Character / emotion off",
+      "chinese_too_hard": "Chinese too hard",
+      "comic_confusing": "Comic confusing",
+      "image_quality": "Image quality issue",
+      "other": "Other"
+    }
+  },
+  "futureBooks": {
+    "title": "What to read next?",
+    "description": "Tell us which classic you'd love to read. We'll notify you when it's ready.",
+    "prompt": "Which one do you want most?",
+    "notify": "Notify me",
+    "privacy": "We'll only notify you when the book is ready to read.",
+    "success": "Got it! We'll let you know when your pick is ready.",
+    "selectBook": "Please select a book.",
+    "invalidEmail": "Please enter a valid email address.",
+    "submitError": "Submission failed. Please try again later.",
+    "networkError": "Network error. Please try again later.",
+    "books": {
+      "xiyouji": "Journey to the West",
+      "shuihu": "Water Margin",
+      "hongloumeng": "Dream of the Red Chamber",
+      "jinpingmei": "Jin Ping Mei"
+    }
+  },
+  "locale": {
+    "passageUnavailable": "This passage is not yet available in {locale}.",
+    "readInOther": "Read in Chinese"
+  }
+}

--- a/site/i18n/locales/zh.json
+++ b/site/i18n/locales/zh.json
@@ -1,0 +1,77 @@
+{
+  "common": {
+    "home": "首页",
+    "library": "书库",
+    "allBooks": "全部书目",
+    "text": "正文",
+    "comic": "漫画",
+    "previous": "上一节",
+    "next": "下一节",
+    "backToChapter": "返回章节",
+    "backToText": "返回正文",
+    "submitting": "提交中…",
+    "noContent": "暂无内容。"
+  },
+  "landing": {
+    "heroTitle": "让中国经典更加生动",
+    "cta": "开始阅读《三国演义》"
+  },
+  "read": {
+    "pageTitle": "阅读中国经典",
+    "openBook": "打开这本书"
+  },
+  "bookmark": {
+    "label": "阅读书签",
+    "title": "继续上次阅读",
+    "continue": "继续阅读"
+  },
+  "chapter": {
+    "collapse": "收起章节",
+    "expand": "展开章节"
+  },
+  "comic": {
+    "description": "用漫画模式阅读这一节，需要时再随时回到正文。"
+  },
+  "feedback": {
+    "disclosure": "本文和漫画由 AI 辅助生成，并经过编辑流程整理。",
+    "like": "赞一下",
+    "report": "有问题？告诉我们",
+    "prompt": "你觉得哪里有问题？",
+    "placeholder": "请描述一下具体问题…",
+    "submit": "提交反馈",
+    "success": "感谢反馈！",
+    "submitError": "提交失败，请稍后再试。",
+    "networkError": "网络错误，请稍后再试。",
+    "selectReason": "请选择一个问题。",
+    "reasons": {
+      "story_not_engaging": "故事不好看",
+      "character_wrong": "人物不像 / 情绪不对",
+      "chinese_too_hard": "中文太难",
+      "comic_confusing": "漫画看不懂",
+      "image_quality": "图片质量有问题",
+      "other": "其他"
+    }
+  },
+  "futureBooks": {
+    "title": "下一本读什么？",
+    "description": "告诉我们你最想读的经典，开始制作时通知你。",
+    "prompt": "你最想读哪一本？",
+    "notify": "通知我",
+    "privacy": "我们只会在这本书可读时通知你。",
+    "success": "收到了！我们会在你选的书可读时通知你。",
+    "selectBook": "请选择一本书。",
+    "invalidEmail": "请输入有效的邮箱地址。",
+    "submitError": "提交失败，请稍后再试。",
+    "networkError": "网络错误，请稍后再试。",
+    "books": {
+      "xiyouji": "西游记",
+      "shuihu": "水浒传",
+      "hongloumeng": "红楼梦",
+      "jinpingmei": "金瓶梅"
+    }
+  },
+  "locale": {
+    "passageUnavailable": "这段内容暂无{locale}版本。",
+    "readInOther": "阅读中文版"
+  }
+}

--- a/site/middleware.ts
+++ b/site/middleware.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const SUPPORTED_LOCALES = ["zh", "en"];
+const ZH_REGIONS = ["zh-cn", "zh-tw", "zh-hk", "zh-mo", "zh-sg"];
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Skip static files, API routes, and internal Next.js paths
+  if (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/api") ||
+    pathname.startsWith("/content") ||
+    pathname.includes(".")
+  ) {
+    return NextResponse.next();
+  }
+
+  // Already on a locale path — do nothing
+  if (SUPPORTED_LOCALES.some((loc) => pathname === `/${loc}` || pathname.startsWith(`/${loc}/`))) {
+    return NextResponse.next();
+  }
+
+  // Check for saved preference in cookie
+  const cookieLocale = request.cookies.get("locale")?.value;
+  if (cookieLocale && SUPPORTED_LOCALES.includes(cookieLocale)) {
+    return NextResponse.redirect(new URL(`/${cookieLocale}${pathname}`, request.url));
+  }
+
+  // Detect from Accept-Language: Greater China → zh, everything else → en
+  const acceptLanguage = request.headers.get("accept-language") || "";
+  const languages = acceptLanguage
+    .split(",")
+    .map((part) => part.trim().split(";")[0].trim().toLowerCase());
+
+  const isZh = languages.some((lang) => ZH_REGIONS.some((zr) => lang === zr || lang === "zh"));
+  const targetLocale = isZh ? "zh" : "en";
+
+  return NextResponse.redirect(new URL(`/${targetLocale}${pathname}`, request.url));
+}
+
+export const config = {
+  matcher: ["/((?!_next|api|content|favicon.ico|.*\\..*).*)"],
+};


### PR DESCRIPTION
## Summary
- Closes #50
- Create translation system (`site/i18n/`) with `zh.json` and `en.json` dictionaries, replacing all hardcoded Chinese UI strings with `getDictionary(locale)` lookups
- Add `/[locale]/` landing page and `/[locale]/read` index page for both zh and en
- Add Next.js middleware for automatic locale detection: Greater China (zh-CN, zh-TW, zh-HK, zh-MO, zh-SG) → zh, everything else → en
- Move language switcher into SiteFooter for consistent access across all pages
- Fix bug where English catchup text was leaking into zh locale on `/zh/read/sanguo`

## Test plan
- [ ] Visit `/` — should redirect based on browser language (zh-CN → `/zh`, en → `/en`)
- [ ] Visit `/zh` and `/en` — landing pages display in correct language
- [ ] Visit `/zh/read/sanguo` — passage titles and catchup text in Chinese
- [ ] Visit `/en/read/sanguo` — passage titles in English where available
- [ ] Click language switcher in footer — switches between zh/en
- [ ] Verify all passage, chapter, comic pages render correctly in both locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)