### PR TITLE
Add English readability feedback categories and locale-aware feedback

### DIFF
--- a/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
+++ b/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
@@ -98,7 +98,7 @@ export default async function LocaleComicPage({ params }: LocaleComicPageProps) 
               routeParams={{ bookId, chapterId, passageId }}
             />
 
-            <PassageFeedback mode="comic" passagePath={{ bookId, chapterId, passageId }} />
+            <PassageFeedback mode="comic" passagePath={{ bookId, chapterId, passageId }} locale={safeLocale} />
           </article>
         </div>
       </section>

--- a/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/page.tsx
+++ b/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/page.tsx
@@ -173,7 +173,7 @@ export default async function LocalePassagePage({ params }: LocalePassagePagePro
               )}
             </div>
 
-            <PassageFeedback mode="text" passagePath={{ bookId, chapterId, passageId }} />
+            <PassageFeedback mode="text" passagePath={{ bookId, chapterId, passageId }} locale={safeLocale} />
 
             <div className="passage-footer-nav">
               {previousPassage ? (

--- a/site/app/api/passage-feedback/route.ts
+++ b/site/app/api/passage-feedback/route.ts
@@ -1,11 +1,16 @@
 const REASONS = [
-  { id: "liked", label: "赞", category: "Positive Signal" },
-  { id: "story_not_engaging", label: "故事不好看", category: "Story Review" },
-  { id: "character_wrong", label: "人物不像 / 情绪不对", category: "Story Review" },
-  { id: "chinese_too_hard", label: "中文太难", category: "Readability" },
-  { id: "comic_confusing", label: "漫画看不懂", category: "Comic QA" },
-  { id: "image_quality", label: "图片质量有问题", category: "Comic QA" },
-  { id: "other", label: "其他", category: "Manual Triage" },
+  { id: "liked", label: "赞", labelEn: "Like", category: "Positive Signal" },
+  { id: "story_not_engaging", label: "故事不好看", labelEn: "Story not engaging", category: "Story Review" },
+  { id: "character_wrong", label: "人物不像 / 情绪不对", labelEn: "Character / emotion off", category: "Story Review" },
+  { id: "chinese_too_hard", label: "中文太难", labelEn: null, category: "Readability" },
+  { id: "comic_confusing", label: "漫画看不懂", labelEn: "Comic confusing", category: "Comic QA" },
+  { id: "image_quality", label: "图片质量有问题", labelEn: "Image quality issue", category: "Comic QA" },
+  { id: "clarity", label: null, labelEn: "Hard to understand", category: "EN Readability" },
+  { id: "naturalness", label: null, labelEn: "Unnatural English", category: "EN Readability" },
+  { id: "culture_fit", label: null, labelEn: "Culture gap / context missing", category: "EN Readability" },
+  { id: "name_confusion", label: null, labelEn: "Names / terms confusing", category: "EN Readability" },
+  { id: "story_flow", label: null, labelEn: "Story flow broken", category: "EN Readability" },
+  { id: "other", label: "其他", labelEn: "Other", category: "Manual Triage" },
 ] as const;
 
 const REASON_IDS = new Set<string>(REASONS.map((r) => r.id));
@@ -21,6 +26,7 @@ type Body = {
   mode?: string;
   reason?: string;
   detail?: string;
+  locale?: string;
   website?: string; // honeypot
 };
 
@@ -43,6 +49,7 @@ export async function POST(request: Request): Promise<Response> {
   const mode = (body.mode ?? "").trim();
   const reason = (body.reason ?? "").trim();
   const detail = (body.detail ?? "").trim();
+  const locale = (body.locale ?? "zh").trim();
 
   if (!bookId || !chapterId || !passageId) {
     return Response.json({ error: "Missing passage path." }, { status: 422 });
@@ -65,11 +72,15 @@ export async function POST(request: Request): Promise<Response> {
         ? [{ type: "section", text: { type: "mrkdwn", text: `*Detail:*\n${detail}` } }]
         : [];
 
+      const displayLabel = locale === "en" && reasonEntry.labelEn
+        ? reasonEntry.labelEn
+        : (reasonEntry.label ?? reasonEntry.labelEn ?? reason);
+
       await fetch(webhookUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          text: `📝 Passage feedback: *${reasonEntry.label}* [${reasonEntry.category}] — ${bookId}/${chapterId}/${passageId} (${mode})`,
+          text: `📝 Passage feedback: *${displayLabel}* [${reasonEntry.category}] — ${bookId}/${chapterId}/${passageId} (${mode}, ${locale})`,
           blocks: [
             {
               type: "section",
@@ -83,7 +94,8 @@ export async function POST(request: Request): Promise<Response> {
               fields: [
                 { type: "mrkdwn", text: `*Passage:*\n${bookId}/${chapterId}/${passageId}` },
                 { type: "mrkdwn", text: `*Mode:*\n${mode}` },
-                { type: "mrkdwn", text: `*Reason:*\n${reasonEntry.label}` },
+                { type: "mrkdwn", text: `*Locale:*\n${locale}` },
+                { type: "mrkdwn", text: `*Reason:*\n${displayLabel}` },
                 { type: "mrkdwn", text: `*Category:*\n${reasonEntry.category}` },
                 { type: "mrkdwn", text: `*Source:*\n${request.headers.get("referer") ?? "unknown"}` },
                 { type: "mrkdwn", text: `*Time:*\n${new Date().toISOString()}` },

--- a/site/app/api/passage-feedback/route.ts
+++ b/site/app/api/passage-feedback/route.ts
@@ -25,6 +25,7 @@ type Body = {
   passageId?: string;
   mode?: string;
   reason?: string;
+  reasons?: string[];
   detail?: string;
   locale?: string;
   website?: string; // honeypot
@@ -47,9 +48,11 @@ export async function POST(request: Request): Promise<Response> {
   const chapterId = (body.chapterId ?? "").trim();
   const passageId = (body.passageId ?? "").trim();
   const mode = (body.mode ?? "").trim();
-  const reason = (body.reason ?? "").trim();
   const detail = (body.detail ?? "").trim();
   const locale = (body.locale ?? "zh").trim();
+
+  // Support both single reason (liked) and multiple reasons
+  const rawReasons = Array.isArray(body.reasons) ? body.reasons : (body.reason ? [body.reason] : []);
 
   if (!bookId || !chapterId || !passageId) {
     return Response.json({ error: "Missing passage path." }, { status: 422 });
@@ -59,8 +62,8 @@ export async function POST(request: Request): Promise<Response> {
     return Response.json({ error: "Invalid mode." }, { status: 422 });
   }
 
-  const reasonEntry = REASON_MAP.get(reason);
-  if (!reasonEntry) {
+  const validReasons = rawReasons.filter((r) => REASON_IDS.has(r));
+  if (rawReasons.length > 0 && validReasons.length === 0) {
     return Response.json({ error: "Invalid reason." }, { status: 422 });
   }
 
@@ -72,15 +75,25 @@ export async function POST(request: Request): Promise<Response> {
         ? [{ type: "section", text: { type: "mrkdwn", text: `*Detail:*\n${detail}` } }]
         : [];
 
-      const displayLabel = locale === "en" && reasonEntry.labelEn
-        ? reasonEntry.labelEn
-        : (reasonEntry.label ?? reasonEntry.labelEn ?? reason);
+      const isLiked = validReasons.length === 0;
+      const reasonLabels = isLiked
+        ? ["liked"]
+        : validReasons.map((r) => {
+            const entry = REASON_MAP.get(r);
+            if (!entry) return r;
+            return locale === "en" && entry.labelEn
+              ? entry.labelEn
+              : (entry.label ?? entry.labelEn ?? r);
+          });
+      const categories = isLiked
+        ? ["Positive Signal"]
+        : [...new Set(validReasons.map((r) => REASON_MAP.get(r)?.category).filter(Boolean))];
 
       await fetch(webhookUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          text: `📝 Passage feedback: *${displayLabel}* [${reasonEntry.category}] — ${bookId}/${chapterId}/${passageId} (${mode}, ${locale})`,
+          text: `📝 Passage feedback: *${reasonLabels.join(", ")}* [${categories.join(", ")}] — ${bookId}/${chapterId}/${passageId} (${mode}, ${locale})`,
           blocks: [
             {
               type: "section",
@@ -95,8 +108,8 @@ export async function POST(request: Request): Promise<Response> {
                 { type: "mrkdwn", text: `*Passage:*\n${bookId}/${chapterId}/${passageId}` },
                 { type: "mrkdwn", text: `*Mode:*\n${mode}` },
                 { type: "mrkdwn", text: `*Locale:*\n${locale}` },
-                { type: "mrkdwn", text: `*Reason:*\n${displayLabel}` },
-                { type: "mrkdwn", text: `*Category:*\n${reasonEntry.category}` },
+                { type: "mrkdwn", text: `*Reasons:*\n${reasonLabels.join(", ")}` },
+                { type: "mrkdwn", text: `*Categories:*\n${categories.join(", ")}` },
                 { type: "mrkdwn", text: `*Source:*\n${request.headers.get("referer") ?? "unknown"}` },
                 { type: "mrkdwn", text: `*Time:*\n${new Date().toISOString()}` },
               ],

--- a/site/components/passage-feedback.tsx
+++ b/site/components/passage-feedback.tsx
@@ -51,7 +51,7 @@ function isCached(path: Props["passagePath"], mode: string): boolean {
 async function submitFeedback(
   passagePath: Props["passagePath"],
   mode: string,
-  reason: string,
+  reasons: string[],
   detail: string | undefined,
   locale: string,
 ): Promise<{ ok: boolean; error?: string }> {
@@ -59,7 +59,7 @@ async function submitFeedback(
     const res = await fetch("/api/passage-feedback", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...passagePath, mode, reason, detail, locale }),
+      body: JSON.stringify({ ...passagePath, mode, reasons, detail, locale }),
     });
 
     if (!res.ok) {
@@ -82,12 +82,12 @@ const ZH_TEXT = {
   disclosure: "本文和漫画由 AI 辅助生成，并经过编辑流程整理。",
   like: "赞一下",
   report: "有问题？告诉我们",
-  prompt: "你觉得哪里有问题？",
+  prompt: "你觉得哪里有问题？（可多选）",
   placeholder: "请描述一下具体问题…",
   submitting: "提交中…",
   submit: "提交反馈",
   success: "感谢反馈！",
-  selectReason: "请选择一个问题。",
+  selectReason: "请至少选择一个问题。",
   submitError: "提交失败，请稍后再试。",
   networkError: "网络错误，请稍后再试。",
 } as const;
@@ -96,12 +96,12 @@ const EN_TEXT = {
   disclosure: "Text and comics are AI-assisted and edited by humans.",
   like: "Like",
   report: "Issue? Tell us",
-  prompt: "What's the problem?",
+  prompt: "What's the problem? (pick all that apply)",
   placeholder: "Describe the issue…",
   submitting: "Submitting…",
   submit: "Submit feedback",
   success: "Thanks for your feedback!",
-  selectReason: "Please select an issue.",
+  selectReason: "Please select at least one issue.",
   submitError: "Submission failed. Please try again later.",
   networkError: "Network error. Please try again later.",
 } as const;
@@ -112,7 +112,7 @@ export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
   const reasons = isEn ? EN_REASONS : ZH_REASONS;
 
   const [status, setStatus] = useState<Status>("idle");
-  const [selectedReason, setSelectedReason] = useState("");
+  const [selectedReasons, setSelectedReasons] = useState<Set<string>>(new Set());
   const [detail, setDetail] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -127,9 +127,24 @@ export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
     return error || t.submitError;
   }
 
+  function toggleReason(id: string) {
+    setSelectedReasons((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+        if (id !== "other") {
+          // keep detail only if "other" is still selected
+        }
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }
+
   async function handleLike() {
     setStatus("submitting");
-    const result = await submitFeedback(passagePath, mode, "liked", undefined, locale);
+    const result = await submitFeedback(passagePath, mode, [], undefined, locale);
     if (result.ok) {
       cacheSubmit(passagePath, mode);
       setStatus("success");
@@ -147,14 +162,14 @@ export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
     e.preventDefault();
     setErrorMessage("");
 
-    if (!selectedReason) {
+    if (selectedReasons.size === 0) {
       setErrorMessage(t.selectReason);
       return;
     }
 
     setStatus("submitting");
-    const detailValue = selectedReason === "other" ? detail.trim() : undefined;
-    const result = await submitFeedback(passagePath, mode, selectedReason, detailValue, locale);
+    const detailValue = selectedReasons.has("other") ? detail.trim() : undefined;
+    const result = await submitFeedback(passagePath, mode, [...selectedReasons], detailValue, locale);
     if (result.ok) {
       cacheSubmit(passagePath, mode);
       setStatus("success");
@@ -196,14 +211,14 @@ export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
             {reasons.map((r) => (
               <label
                 key={r.id}
-                className={`passage-feedback-reason ${selectedReason === r.id ? "passage-feedback-reason-selected" : ""}`}
+                className={`passage-feedback-reason ${selectedReasons.has(r.id) ? "passage-feedback-reason-selected" : ""}`}
               >
                 <input
-                  type="radio"
-                  name="reason"
+                  type="checkbox"
+                  name="reasons"
                   value={r.id}
-                  checked={selectedReason === r.id}
-                  onChange={() => { setSelectedReason(r.id); if (r.id !== "other") setDetail(""); }}
+                  checked={selectedReasons.has(r.id)}
+                  onChange={() => toggleReason(r.id)}
                   className="visually-hidden"
                 />
                 {r.label}
@@ -211,7 +226,7 @@ export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
             ))}
           </div>
 
-          {selectedReason === "other" && (
+          {selectedReasons.has("other") && (
             <textarea
               className="passage-feedback-detail"
               value={detail}

--- a/site/components/passage-feedback.tsx
+++ b/site/components/passage-feedback.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, type FormEvent } from "react";
 
-const NEGATIVE_REASONS = [
+const ZH_REASONS = [
   { id: "story_not_engaging", label: "故事不好看" },
   { id: "character_wrong", label: "人物不像 / 情绪不对" },
   { id: "chinese_too_hard", label: "中文太难" },
@@ -11,11 +11,25 @@ const NEGATIVE_REASONS = [
   { id: "other", label: "其他" },
 ] as const;
 
+const EN_REASONS = [
+  { id: "story_not_engaging", label: "Story not engaging" },
+  { id: "character_wrong", label: "Character / emotion off" },
+  { id: "clarity", label: "Hard to understand" },
+  { id: "naturalness", label: "Unnatural English" },
+  { id: "culture_fit", label: "Culture gap / context missing" },
+  { id: "name_confusion", label: "Names / terms confusing" },
+  { id: "story_flow", label: "Story flow broken" },
+  { id: "comic_confusing", label: "Comic confusing" },
+  { id: "image_quality", label: "Image quality issue" },
+  { id: "other", label: "Other" },
+] as const;
+
 const CACHE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
 type Props = {
   mode: "text" | "comic";
   passagePath: { bookId: string; chapterId: string; passageId: string };
+  locale?: "zh" | "en";
 };
 
 type Status = "idle" | "expanded" | "submitting" | "success" | "error";
@@ -38,22 +52,23 @@ async function submitFeedback(
   passagePath: Props["passagePath"],
   mode: string,
   reason: string,
-  detail?: string,
+  detail: string | undefined,
+  locale: string,
 ): Promise<{ ok: boolean; error?: string }> {
   try {
     const res = await fetch("/api/passage-feedback", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ...passagePath, mode, reason, detail }),
+      body: JSON.stringify({ ...passagePath, mode, reason, detail, locale }),
     });
 
     if (!res.ok) {
       const data = await res.json();
-      return { ok: false, error: data.error || "提交失败，请稍后再试。" };
+      return { ok: false, error: data.error };
     }
     return { ok: true };
   } catch {
-    return { ok: false, error: "网络错误，请稍后再试。" };
+    return { ok: false, error: "network" };
   }
 }
 
@@ -63,7 +78,39 @@ function cacheSubmit(path: Props["passagePath"], mode: string) {
   } catch {}
 }
 
-export function PassageFeedback({ mode, passagePath }: Props) {
+const ZH_TEXT = {
+  disclosure: "本文和漫画由 AI 辅助生成，并经过编辑流程整理。",
+  like: "赞一下",
+  report: "有问题？告诉我们",
+  prompt: "你觉得哪里有问题？",
+  placeholder: "请描述一下具体问题…",
+  submitting: "提交中…",
+  submit: "提交反馈",
+  success: "感谢反馈！",
+  selectReason: "请选择一个问题。",
+  submitError: "提交失败，请稍后再试。",
+  networkError: "网络错误，请稍后再试。",
+} as const;
+
+const EN_TEXT = {
+  disclosure: "Text and comics are AI-assisted and edited by humans.",
+  like: "Like",
+  report: "Issue? Tell us",
+  prompt: "What's the problem?",
+  placeholder: "Describe the issue…",
+  submitting: "Submitting…",
+  submit: "Submit feedback",
+  success: "Thanks for your feedback!",
+  selectReason: "Please select an issue.",
+  submitError: "Submission failed. Please try again later.",
+  networkError: "Network error. Please try again later.",
+} as const;
+
+export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
+  const isEn = locale === "en";
+  const t = isEn ? EN_TEXT : ZH_TEXT;
+  const reasons = isEn ? EN_REASONS : ZH_REASONS;
+
   const [status, setStatus] = useState<Status>("idle");
   const [selectedReason, setSelectedReason] = useState("");
   const [detail, setDetail] = useState("");
@@ -75,14 +122,19 @@ export function PassageFeedback({ mode, passagePath }: Props) {
     }
   }, [passagePath, mode]);
 
+  function resolveError(error?: string): string {
+    if (error === "network") return t.networkError;
+    return error || t.submitError;
+  }
+
   async function handleLike() {
     setStatus("submitting");
-    const result = await submitFeedback(passagePath, mode, "liked");
+    const result = await submitFeedback(passagePath, mode, "liked", undefined, locale);
     if (result.ok) {
       cacheSubmit(passagePath, mode);
       setStatus("success");
     } else {
-      setErrorMessage(result.error || "提交失败。");
+      setErrorMessage(resolveError(result.error));
       setStatus("error");
     }
   }
@@ -96,18 +148,18 @@ export function PassageFeedback({ mode, passagePath }: Props) {
     setErrorMessage("");
 
     if (!selectedReason) {
-      setErrorMessage("请选择一个问题。");
+      setErrorMessage(t.selectReason);
       return;
     }
 
     setStatus("submitting");
     const detailValue = selectedReason === "other" ? detail.trim() : undefined;
-    const result = await submitFeedback(passagePath, mode, selectedReason, detailValue);
+    const result = await submitFeedback(passagePath, mode, selectedReason, detailValue, locale);
     if (result.ok) {
       cacheSubmit(passagePath, mode);
       setStatus("success");
     } else {
-      setErrorMessage(result.error || "提交失败。");
+      setErrorMessage(resolveError(result.error));
       setStatus("error");
     }
   }
@@ -115,7 +167,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
   return (
     <div className="passage-feedback">
       <p className="passage-feedback-disclosure">
-        本文和漫画由 AI 辅助生成，并经过编辑流程整理。
+        {t.disclosure}
       </p>
 
       {status === "idle" && (
@@ -125,23 +177,23 @@ export function PassageFeedback({ mode, passagePath }: Props) {
             className="passage-feedback-like"
             onClick={handleLike}
           >
-            赞一下
+            {t.like}
           </button>
           <button
             type="button"
             className="passage-feedback-toggle"
             onClick={handleExpand}
           >
-            有问题？告诉我们
+            {t.report}
           </button>
         </div>
       )}
 
       {status === "expanded" || status === "submitting" || status === "error" ? (
         <form onSubmit={handleSubmit} noValidate>
-          <p className="passage-feedback-prompt">你觉得哪里有问题？</p>
+          <p className="passage-feedback-prompt">{t.prompt}</p>
           <div className="passage-feedback-reasons">
-            {NEGATIVE_REASONS.map((r) => (
+            {reasons.map((r) => (
               <label
                 key={r.id}
                 className={`passage-feedback-reason ${selectedReason === r.id ? "passage-feedback-reason-selected" : ""}`}
@@ -164,7 +216,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
               className="passage-feedback-detail"
               value={detail}
               onChange={(e) => setDetail(e.target.value)}
-              placeholder="请描述一下具体问题…"
+              placeholder={t.placeholder}
               rows={2}
             />
           )}
@@ -174,7 +226,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
             className="button-link button-link-secondary passage-feedback-submit"
             disabled={status === "submitting"}
           >
-            {status === "submitting" ? "提交中…" : "提交反馈"}
+            {status === "submitting" ? t.submitting : t.submit}
           </button>
 
           {errorMessage && (
@@ -184,7 +236,7 @@ export function PassageFeedback({ mode, passagePath }: Props) {
       ) : null}
 
       {status === "success" && (
-        <p className="passage-feedback-success">感谢反馈！</p>
+        <p className="passage-feedback-success">{t.success}</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- Closes #54
- Add English-specific feedback reasons: clarity, naturalness, culture fit, name confusion, story flow — only shown when locale=en
- Pass `locale` in feedback API payload so English feedback is identifiable
- Include `locale` in Slack notification for triage
- Chinese feedback unchanged — same reasons and labels as before

## EN feedback categories (new)
| ID | Label | Category |
|---|---|---|
| `clarity` | Hard to understand | EN Readability |
| `naturalness` | Unnatural English | EN Readability |
| `culture_fit` | Culture gap / context missing | EN Readability |
| `name_confusion` | Names / terms confusing | EN Readability |
| `story_flow` | Story flow broken | EN Readability |

## Test plan
- [ ] Chinese passage feedback shows original 6 reasons (故事不好看, 人物不像, etc.)
- [ ] English passage feedback shows 10 reasons (Story not engaging + 5 EN readability + Comic + Other)
- [ ] Like button works in both locales
- [ ] Slack notification includes `Locale: en` field for English feedback
- [ ] Chinese feedback Slack notification unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)