### PR TITLE
[codex] Add GA4 funnel tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,3 +86,21 @@ source chapter
 - Keep context local to the current passage
 - Use working memory, not full-history prompt stuffing
 - `memory/story_events.jsonl` only stores story-content events, not pipeline/process events
+
+## Site Analytics
+
+The website supports a small GA4 layer for funnel validation.
+
+- Configure `NEXT_PUBLIC_GA_MEASUREMENT_ID` in the site runtime to enable GA4.
+- When the variable is unset, analytics code stays inert and the site should behave normally.
+- Current tracked events:
+  - `page_view`
+  - `landing_cta_click`
+  - `read_start`
+  - `comic_view`
+  - `language_switch`
+  - `passage_feedback_submit`
+  - `follow_subscribe_submit`
+  - `future_book_interest_submit`
+- Common params include `locale`, `book_id`, `chapter_id`, `passage_id`, `mode`, `trigger`, `target_locale`, and `feedback_kind` where relevant.
+- Validate locally with GA4 DebugView after setting the measurement ID and navigating through landing, reader, comic, feedback, and email capture flows.

--- a/site/.env.prod
+++ b/site/.env.prod
@@ -1,1 +1,2 @@
 CONTENT_BASE_URL=https://storage.googleapis.com/zh-books
+NEXT_PUBLIC_GA_MEASUREMENT_ID=G-X3L8J878VD

--- a/site/app/[locale]/page.tsx
+++ b/site/app/[locale]/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { LandingCtaLink } from "@/components/landing-cta-link";
 import { SiteFooter } from "@/components/site-footer";
 import { getDictionary } from "@/i18n";
 import type { Locale } from "@/lib/types";
@@ -25,9 +25,13 @@ export default async function LocaleHomePage({ params }: LocaleHomePageProps) {
           <div className="container home-hero-inner">
             <h1 className="home-hero-title">{t.landing.heroTitle}</h1>
             <div className="home-hero-actions">
-              <Link className="button-link button-link-accent home-hero-cta" href={`/${safeLocale}/read`}>
+              <LandingCtaLink
+                className="button-link button-link-accent home-hero-cta"
+                href={`/${safeLocale}/read`}
+                locale={safeLocale}
+              >
                 {t.landing.cta}
-              </Link>
+              </LandingCtaLink>
             </div>
           </div>
         </section>

--- a/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
+++ b/site/app/[locale]/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { ComicViewTracker } from "@/components/comic-view-tracker";
 import { ComicImageBlock } from "@/components/comic-image-block";
 import { ModeHeader } from "@/components/mode-header";
 import { PassageFeedback } from "@/components/passage-feedback";
@@ -50,6 +51,7 @@ export default async function LocaleComicPage({ params }: LocaleComicPageProps) 
 
   return (
     <main className="page-shell passage-page">
+      <ComicViewTracker bookId={bookId} chapterId={chapterId} passageId={passageId} locale={safeLocale} />
       <ModeHeader
         bookLabel={bookTitle}
         chapterLabel={chapterLabel}

--- a/site/app/layout.tsx
+++ b/site/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
+import { AnalyticsRouteTracker } from "@/components/analytics-route-tracker";
+import { GoogleAnalytics } from "@/components/google-analytics";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -14,7 +16,13 @@ type RootLayoutProps = {
 export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="zh-CN">
-      <body>{children}</body>
+      <body>
+        <GoogleAnalytics />
+        <Suspense fallback={null}>
+          <AnalyticsRouteTracker />
+        </Suspense>
+        {children}
+      </body>
     </html>
   );
 }

--- a/site/app/page.tsx
+++ b/site/app/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { LandingCtaLink } from "@/components/landing-cta-link";
 import { SiteFooter } from "@/components/site-footer";
 import { getDictionary } from "@/i18n";
 
@@ -12,9 +12,9 @@ export default async function HomePage() {
           <div className="container home-hero-inner">
             <h1 className="home-hero-title">{t.landing.heroTitle}</h1>
             <div className="home-hero-actions">
-              <Link className="button-link button-link-accent home-hero-cta" href="/read">
+              <LandingCtaLink className="button-link button-link-accent home-hero-cta" href="/read" locale="zh">
                 {t.landing.cta}
-              </Link>
+              </LandingCtaLink>
             </div>
           </div>
         </section>

--- a/site/app/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
+++ b/site/app/read/[bookId]/[chapterId]/[passageId]/comic/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { ComicViewTracker } from "@/components/comic-view-tracker";
 import { ComicImageBlock } from "@/components/comic-image-block";
 import { ModeHeader } from "@/components/mode-header";
 import { PassageFeedback } from "@/components/passage-feedback";
@@ -37,6 +38,7 @@ export default async function PassageComicPage({ params }: ComicPageProps) {
 
   return (
     <main className="page-shell passage-page">
+      <ComicViewTracker bookId={bookId} chapterId={chapterId} passageId={passageId} locale="zh" />
       <ModeHeader
         bookLabel={book.title}
         chapterLabel={chapter.adapted_title_cn || chapter.source_title}

--- a/site/components/analytics-route-tracker.tsx
+++ b/site/components/analytics-route-tracker.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { trackPageView } from "@/lib/client/analytics";
+import type { Locale } from "@/lib/types";
+
+function deriveLocale(pathname: string): Locale {
+  if (pathname === "/zh" || pathname.startsWith("/zh/")) return "zh";
+  if (pathname === "/en" || pathname.startsWith("/en/")) return "en";
+  return "zh";
+}
+
+function derivePageType(pathname: string): string {
+  const parts = pathname.split("/").filter(Boolean);
+  const offset = parts[0] === "zh" || parts[0] === "en" ? 1 : 0;
+
+  if (parts.length === offset) return "landing";
+  if (parts[offset] !== "read") return "other";
+  if (parts.length === offset + 1) return "read_index";
+  if (parts.length === offset + 2) return "book";
+  if (parts.length === offset + 3) return "chapter";
+  if (parts.length === offset + 4) return "passage";
+  if (parts.length === offset + 5 && parts[offset + 4] === "comic") return "comic";
+  return "other";
+}
+
+export function AnalyticsRouteTracker() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!pathname) return;
+
+    const query = searchParams?.toString();
+    const path = query ? `${pathname}?${query}` : pathname;
+
+    trackPageView(path, {
+      locale: deriveLocale(pathname),
+      page_type: derivePageType(pathname),
+    });
+  }, [pathname, searchParams]);
+
+  return null;
+}

--- a/site/components/comic-view-tracker.tsx
+++ b/site/components/comic-view-tracker.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect } from "react";
+import { trackEvent } from "@/lib/client/analytics";
+import type { Locale } from "@/lib/types";
+
+type ComicViewTrackerProps = {
+  bookId: string;
+  chapterId: string;
+  passageId: string;
+  locale: Locale;
+};
+
+export function ComicViewTracker({
+  bookId,
+  chapterId,
+  passageId,
+  locale,
+}: ComicViewTrackerProps) {
+  useEffect(() => {
+    trackEvent("comic_view", {
+      locale,
+      book_id: bookId,
+      chapter_id: chapterId,
+      passage_id: passageId,
+      mode: "comic",
+    });
+  }, [bookId, chapterId, passageId, locale]);
+
+  return null;
+}

--- a/site/components/follow-subscribe-form.tsx
+++ b/site/components/follow-subscribe-form.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, type FormEvent } from "react";
 import { getDictionary } from "@/i18n";
+import { trackEvent } from "@/lib/client/analytics";
 import type { Locale } from "@/lib/types";
 
 const CACHE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -93,6 +94,13 @@ export function FollowSubscribeForm({
       }
 
       cacheSubmit({ bookId, chapterId, passageId, trigger });
+      trackEvent("follow_subscribe_submit", {
+        locale,
+        book_id: bookId,
+        chapter_id: chapterId,
+        passage_id: passageId,
+        trigger,
+      });
       setStatus("success");
     } catch {
       setErrorMessage(t.followSubscription.networkError);

--- a/site/components/future-book-form.tsx
+++ b/site/components/future-book-form.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, type FormEvent } from "react";
 import { getDictionary } from "@/i18n";
+import { trackEvent } from "@/lib/client/analytics";
 import type { Locale } from "@/lib/types";
 
 const CACHE_KEY = "future-books-submitted";
@@ -71,6 +72,10 @@ export function FutureBookForm({ locale = "zh" }: { locale?: Locale }) {
         localStorage.setItem(CACHE_KEY, String(Date.now() + CACHE_MS));
       } catch {}
 
+      trackEvent("future_book_interest_submit", {
+        locale,
+        book_id: selectedBook,
+      });
       setStatus("success");
     } catch {
       setErrorMessage(t.futureBooks.networkError);

--- a/site/components/google-analytics.tsx
+++ b/site/components/google-analytics.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Script from "next/script";
+import { getGaMeasurementId } from "@/lib/client/analytics";
+
+export function GoogleAnalytics() {
+  const measurementId = getGaMeasurementId();
+
+  if (!measurementId) {
+    return null;
+  }
+
+  return (
+    <>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          window.gtag = gtag;
+          gtag('js', new Date());
+          gtag('config', '${measurementId}', { send_page_view: false });
+        `}
+      </Script>
+    </>
+  );
+}

--- a/site/components/landing-cta-link.tsx
+++ b/site/components/landing-cta-link.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { trackEvent } from "@/lib/client/analytics";
+import type { Locale } from "@/lib/types";
+
+type LandingCtaLinkProps = {
+  href: string;
+  className?: string;
+  locale: Locale;
+  children: ReactNode;
+};
+
+export function LandingCtaLink({ href, className, locale, children }: LandingCtaLinkProps) {
+  return (
+    <Link
+      className={className}
+      href={href}
+      prefetch={false}
+      onClick={() => {
+        trackEvent("landing_cta_click", {
+          locale,
+          destination: href,
+        });
+      }}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/site/components/language-switch.tsx
+++ b/site/components/language-switch.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { trackEvent } from "@/lib/client/analytics";
 import type { Locale } from "@/lib/types";
 
 type LanguageSwitchProps = {
@@ -44,6 +45,12 @@ export function LanguageSwitch({ currentLocale, availableLocales, localeHrefs }:
             href={localeHrefs[locale]}
             prefetch={false}
             lang={locale}
+            onClick={() => {
+              trackEvent("language_switch", {
+                locale: currentLocale,
+                target_locale: locale,
+              });
+            }}
           >
             {localeLabels[locale]}
           </Link>

--- a/site/components/passage-feedback.tsx
+++ b/site/components/passage-feedback.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, type FormEvent } from "react";
 import { getDictionary } from "@/i18n";
+import { trackEvent } from "@/lib/client/analytics";
 import type { Locale } from "@/lib/types";
 
 const ZH_REASON_IDS = [
@@ -117,6 +118,14 @@ export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
     const result = await submitFeedback(passagePath, mode, [], undefined, locale);
     if (result.ok) {
       cacheSubmit(passagePath, mode);
+      trackEvent("passage_feedback_submit", {
+        locale,
+        book_id: passagePath.bookId,
+        chapter_id: passagePath.chapterId,
+        passage_id: passagePath.passageId,
+        mode,
+        feedback_kind: "liked",
+      });
       setStatus("success");
     } else {
       setErrorMessage(resolveError(result.error));
@@ -142,6 +151,14 @@ export function PassageFeedback({ mode, passagePath, locale = "zh" }: Props) {
     const result = await submitFeedback(passagePath, mode, [...selectedReasons], detailValue, locale);
     if (result.ok) {
       cacheSubmit(passagePath, mode);
+      trackEvent("passage_feedback_submit", {
+        locale,
+        book_id: passagePath.bookId,
+        chapter_id: passagePath.chapterId,
+        passage_id: passagePath.passageId,
+        mode,
+        feedback_kind: [...selectedReasons].join(","),
+      });
       setStatus("success");
     } else {
       setErrorMessage(resolveError(result.error));

--- a/site/components/reading-session-tracker.tsx
+++ b/site/components/reading-session-tracker.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect } from "react";
+import { trackEvent } from "@/lib/client/analytics";
 import { useReadingSession } from "@/lib/client/user-session";
 
 export function ReadingSessionTracker({
@@ -12,5 +14,17 @@ export function ReadingSessionTracker({
   passageId: string;
 }) {
   useReadingSession(bookId, chapterId, passageId);
+
+  useEffect(() => {
+    const locale = window.location.pathname.startsWith("/en") ? "en" : "zh";
+    trackEvent("read_start", {
+      locale,
+      book_id: bookId,
+      chapter_id: chapterId,
+      passage_id: passageId,
+      mode: "text",
+    });
+  }, [bookId, chapterId, passageId]);
+
   return null;
 }

--- a/site/lib/client/analytics.ts
+++ b/site/lib/client/analytics.ts
@@ -1,0 +1,46 @@
+"use client";
+
+export type AnalyticsParams = Record<string, string | number | boolean | null | undefined>;
+
+declare global {
+  interface Window {
+    dataLayer?: unknown[];
+    gtag?: (
+      command: "js" | "config" | "event" | "set",
+      targetId: string | Date,
+      params?: AnalyticsParams,
+    ) => void;
+  }
+}
+
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID?.trim() ?? "";
+
+function isAnalyticsEnabled(): boolean {
+  return typeof window !== "undefined" && Boolean(GA_MEASUREMENT_ID) && typeof window.gtag === "function";
+}
+
+function cleanParams(params: AnalyticsParams = {}): AnalyticsParams {
+  return Object.fromEntries(
+    Object.entries(params).filter(([, value]) => value !== undefined && value !== null && value !== ""),
+  );
+}
+
+export function getGaMeasurementId(): string {
+  return GA_MEASUREMENT_ID;
+}
+
+export function trackPageView(path: string, params: AnalyticsParams = {}) {
+  if (!isAnalyticsEnabled()) return;
+
+  window.gtag!("event", "page_view", cleanParams({
+    page_path: path,
+    page_location: window.location.href,
+    page_title: document.title,
+    ...params,
+  }));
+}
+
+export function trackEvent(name: string, params: AnalyticsParams = {}) {
+  if (!isAnalyticsEnabled()) return;
+  window.gtag!("event", name, cleanParams(params));
+}


### PR DESCRIPTION
## Summary
- add a minimal GA4 `gtag.js` integration gated by `NEXT_PUBLIC_GA_MEASUREMENT_ID`
- track route page views plus core funnel events for landing CTA, passage start, comic views, language switching, feedback, and email capture
- document the analytics event contract and validation flow

## Why
This adds the client-side GA4 layer for issue #72 without replacing the existing first-party D1 reading session tracking.

## Validation
- `cd site && npm run build`
